### PR TITLE
:memo: :bug: network: Fix headers for RIT VPN article

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-RIT Linux Wiki
-================================================
+[RIT Linux Wiki](https://moralcode.github.io/rit-linux-wiki)
+============================================================
+
+### [_moralcode.github.io/rit-linux-wiki_](https://moralcode.github.io/rit-linux-wiki)
 
 [![License: CC BY-SA 4.0](https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by-sa/4.0)
 [![Build Status](https://circleci.com/gh/MoralCode/rit-linux-wiki/tree/main.svg?style=shield)](https://app.circleci.com/pipelines/github/MoralCode/rit-linux-wiki?branch=main)

--- a/content/network/RIT-VPN.en.md
+++ b/content/network/RIT-VPN.en.md
@@ -7,32 +7,33 @@ weight: 10
 ## Using Network-manager
 These instructions are for network-manager specifically, but should be adaptable for any system
 
-**Step 1:**
-===========
+Step 1:
+=======
 
 Navigate to [https://vpn.rit.edu](https://vpn.rit.edu/) from a linux device and sign in
 
 ![](/rit-linux-wiki/img/rit-vpn/download-login.png)
 
-**​Step 2:**
-============
+Step 2:
+=======
 
-Click the button to download the anyconnect client for linux. You should get a roughly 5-6 Mebibyte .sh script file.
+Click the button to download the anyconnect client for linux. You should get a roughly 5-6 megabyte `.sh` script file.
 
 ![](/rit-linux-wiki/img/rit-vpn/download.png)
 
-**​Step 3: Extract**
-====================
+Step 3: Extract
+===============
 
 This installer script contains an encoded tarball which makes up the bulk of the file. To extract it, use [this script](https://gist.github.com/MoralCode/0e6d3515cc6546ada033a504d95c79f7).
 
 
-**​Step 4: ​Find the certificate**
-==================================
+Step 4: Find the certificate
+============================
 
 Locate and save the file named `VeriSignClass3PublicPrimaryCertificationAuthority-G5.pem`. You will need this to connect.
 
-**​Step 5: Set up connection**
+Step 5: Set up connection
+=========================
 
 Install the package `network-manager-openconnect` from your system's package manager (it should be in at least the ubuntu repos). This adds openconnect (and anyconnect) options to network manager (if your system uses it).
 
@@ -43,12 +44,10 @@ Then go into network manager and create a new vpn profile.
 Change the VPN protocol to "Cisco AnyConnect" and provide the gateway URL (vpn.rit.edu) and certificate file from earlier, you shouldnt need to do anything else.
 
 Step 6: Connect
----------------
+===============
 
-In network manager, connect to the VPN. You should get a window like
-this:
+In network manager, connect to the VPN. You should get a window like this:
 
 ![](/rit-linux-wiki/img/rit-vpn/connecting.png)
 
 To continue connecting, click on the button to the right of the "VPN Host" Dropdown. It may ask for your RIT credentials before connecting you to the VPN.
-


### PR DESCRIPTION
This commit fixes the document headers so they are uniform and display as expected. I also added a link to the knowledge-base in the README.

![Screenshot of RIT VPN article with corrected headers.](https://user-images.githubusercontent.com/4721034/150008720-1b7c0a12-d7eb-48e0-8461-76256db680ff.png "Screenshot of RIT VPN article with corrected headers.")