### PR TITLE
:newspaper_roll: gitignore: Never commit `.hugo_build.lock` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 ##### ---- Hugo ---- #####
 # Generated files by hugo
+.hugo_build.lock
 /public/
 /resources/_gen/
 


### PR DESCRIPTION
This commit adds the `.hugo_build.lock` files to the `.gitignore`. This
file is automatically created since Hugo v0.89.0, see notes below:

> Hugo now writes an empty file named `.hugo_build.lock` to the root of
> the project when building (also when doing `hugo new mypost.md` and
> other commands that requires a build). We recommend you just leave
> this file alone. Put it in `.gitignore` or similar if you don't want
> the file in your source repository.

ref: gohugoio/hugo#9048